### PR TITLE
Fix example code in Python interface document

### DIFF
--- a/docs/source/python_interface.rst
+++ b/docs/source/python_interface.rst
@@ -27,7 +27,7 @@ by writing your own python interface. This is not recommended for most users.
 .. code-block:: python
 
     finder.stock.select("zinc")
-    finder.policy.select("full_uspto")
+    finder.expansion_policy.select("uspto")
 
 `zinc` and `full_uspto` where the keys given to the stock and the policy in the configuration file.
 


### PR DESCRIPTION
Thank you for providing a great tool! I really like this project.

This pull request tries to fix the example code in the document of Python interface.

The current example code `finder.policy.select("full_uspto")` yields an error `AttributeError: 'AiZynthFinder' object has no attribute 'policy'` in my environment.

Judging from other codes, `finder.policy` should be `finder.expansion_policy`.
Also, `full_uspto` does not exist in config.yml generated by download_public_data.py. It should be `uspto`.

If my fix is wrong, please let me know.