### PR TITLE
Add notebook for Google Colaboratory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# aizynthfinder
+# AiZynthFinder [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MolecularAI/aizynthfinder/blob/master/contrib/notebook.ipynb)
 
-aizynthfinder is a tool for retrosynthetic planning. The algorithm is based on a Monte Carlo tree search that recursively breaks down a molecule to purchasable precursors. The tree search is guided by a policy that suggests possible precursors by utilizing a neural network trained on a library of known reaction templates.  
+
+AiZynthFinder is a tool for retrosynthetic planning. The algorithm is based on a Monte Carlo tree search that recursively breaks down a molecule to purchasable precursors. The tree search is guided by a policy that suggests possible precursors by utilizing a neural network trained on a library of known reaction templates.  
 
 ## Prerequisites
 
@@ -43,7 +44,7 @@ python -m pip install -e .
 
 if you are a developer, using the repository.
 
-Note on the graphviz installation: this package does not depend on any third-party python interfaces to graphviz but instead calls the `neato` and `dot` executables directly. If these executable are not in the `$PATH` environmental variable, the generation of route images will not work. If unable to install it properly with the default conda chanel, try using `-c anaconda`. 
+Note on the graphviz installation: this package does not depend on any third-party python interfaces to graphviz but instead calls the `neato` and `dot` executables directly. If these executable are not in the `$PATH` environmental variable, the generation of route images will not work. If unable to install it properly with the default conda chanel, try using `-c anaconda`.
 
 ## Usage
 
@@ -69,12 +70,12 @@ Such files can be downloaded from [figshare](https://figshare.com/articles/AiZyn
 download_public_data my_folder
 ```
 
-where ``my_folder`` is the folder that you want download to. 
+where ``my_folder`` is the folder that you want download to.
 This will create a ``config.yml`` file that you can use with either ``aizynthcli`` or ``aizynthapp``.
 
 ### Testing
 
-Tests uses the ``pytest`` package. 
+Tests uses the ``pytest`` package.
 
 To use, first install the dependencies
 

--- a/contrib/notebook.ipynb
+++ b/contrib/notebook.ipynb
@@ -1,0 +1,66 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "AiZynthFinder.ipynb",
+      "private_outputs": true,
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ObD2YL7nM2_X"
+      },
+      "source": [
+        "# AiZynthFinder\n",
+        "\n",
+        "Click the ▶ play button at the left of the **Start** text below to run the application. The initial installation process may take a few minutes.\n",
+        "\n",
+        "1. Enter the target compound [SMILES][1] code.\n",
+        "3. Click the **Run Search** button to start the algorithm.\n",
+        "4. Once it stops serching, click the **Show Reactions** button.\n",
+        "\n",
+        "[1]: https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "beDP-CSNM429"
+      },
+      "source": [
+        "#@title Start {display-mode: \"form\"}\n",
+        "!curl --location --silent bit.ly/rdkit-colab | tar xz -C /\n",
+        "!pip install --quiet graphviz\n",
+        "!pip install --quiet https://github.com/MolecularAI/aizynthfinder/archive/v2.2.1.tar.gz\n",
+        "!mkdir --parents data && download_public_data data\n",
+        "from rdkit.Chem.Draw import IPythonConsole",
+        "from aizynthfinder.interfaces import AiZynthApp\n",
+        "application = AiZynthApp(\"./data/config.yml\")\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bwxusoogwlI9"
+      },
+      "source": [
+        "# Bibliography\n",
+        "\n",
+        "_Genheden S, Thakkar A, Chadimova V, et al (2020) AiZynthFinder: a fast, robust and flexible open-source software for retrosynthetic planning. J. Cheminf. https://doi.org/10.1186/s13321-020-00472-1 ([GitHub](https://github.com/MolecularAI/aizynthfinder) & [Documentation](https://molecularai.github.io/aizynthfinder/html/index.html))_"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
It would be nice to have a quick way to see AiZynthFinder in action without other requirements than a web browser. This pull request provides a small iPython notebook for running this application directly on Google Colaboratory with two clicks. You can see it in action [here](https://colab.research.google.com/github/0x2b3bfa0/aizynthfinder/blob/main/notebook.ipynb).

By the way, this is an awesome project! 🚀 