### PR TITLE
Remove the tensorflow-gpu mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ conda install -c anaconda "tensorflow>=2.1.0" -y
 conda install graphviz -y
 ```
 
-if you have GPU and CUDA libraries enabled on your machine, you can install the ``tensorflow-gpu`` package instead.
-
 * Secondly, install the ``aizynthfinder`` package
 
 ```


### PR DESCRIPTION
As per the [official documentation][1], GPU support is on the normal `tensorflow` package from Tensorflow 2.0 onwards. Given that we're requiring 2.1.0+, it wouldn't be necessary to provide any additional instructions. 

[1]: https://www.tensorflow.org/install/gpu#older_versions_of_tensorflow