### PR TITLE
[Docs] Visualization of aizynthfinder's codebase.

### DIFF
--- a/.codeboarding/Application_Orchestrator.md
+++ b/.codeboarding/Application_Orchestrator.md
@@ -1,0 +1,215 @@
+```mermaid
+
+graph LR
+
+    Application_Orchestrator["Application Orchestrator"]
+
+    Chemical_Data_Models["Chemical Data Models"]
+
+    Configuration_Strategy_Management["Configuration & Strategy Management"]
+
+    Retrosynthesis_Search_Algorithms["Retrosynthesis Search Algorithms"]
+
+    Route_Analysis_Post_processing["Route Analysis & Post-processing"]
+
+    User_Interfaces["User Interfaces"]
+
+    Utility_Functions_External_Models["Utility Functions & External Models"]
+
+    Application_Orchestrator -- "uses" --> Chemical_Data_Models
+
+    Application_Orchestrator -- "uses" --> Configuration_Strategy_Management
+
+    Application_Orchestrator -- "uses" --> Retrosynthesis_Search_Algorithms
+
+    Application_Orchestrator -- "uses" --> Route_Analysis_Post_processing
+
+    User_Interfaces -- "uses" --> Application_Orchestrator
+
+    Retrosynthesis_Search_Algorithms -- "uses" --> Chemical_Data_Models
+
+    Retrosynthesis_Search_Algorithms -- "uses" --> Configuration_Strategy_Management
+
+    Configuration_Strategy_Management -- "uses" --> Utility_Functions_External_Models
+
+    Route_Analysis_Post_processing -- "uses" --> Chemical_Data_Models
+
+    Route_Analysis_Post_processing -- "uses" --> Configuration_Strategy_Management
+
+    click Application_Orchestrator href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Application_Orchestrator.md" "Details"
+
+    click User_Interfaces href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//User_Interfaces.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Component overview for `Application Orchestrator` and other fundamental components of the `aizynthfinder` project, along with their relationships.
+
+
+
+### Application Orchestrator [[Expand]](./Application_Orchestrator.md)
+
+The `Application Orchestrator` is the core control unit of the `aizynthfinder` system. It initializes and manages the complete retrosynthesis process, from the initial target molecule input to the final collection and analysis of synthetic routes. This component orchestrates the interaction between various sub-systems, including the application of reaction policies, execution of search algorithms, and utilization of scoring functions. It serves as the primary entry point for executing a retrosynthesis plan, ensuring a cohesive and integrated workflow.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `AiZynthFinder` (1:1)
+
+
+
+
+
+### Chemical Data Models
+
+This component provides the fundamental data structures for representing chemical entities such as molecules and reactions. It includes classes for handling molecular properties, unique molecule identification, and the definition of retro-reactions, which are crucial for the retrosynthesis process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Molecule` (1:1)
+
+- `RetroReaction` (1:1)
+
+
+
+
+
+### Configuration & Strategy Management
+
+This component is responsible for managing the application's configuration and injecting various strategies, including expansion policies (how reactions are applied), filter policies (how reactions are pruned), scoring functions (how routes are evaluated), and stock availability queries. It acts as a central context for dependency injection, allowing flexible and extensible behavior.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Configuration` (1:1)
+
+- `ExpansionPolicy` (1:1)
+
+- `FilterPolicy` (1:1)
+
+- `ScorerCollection` (1:1)
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/stock.py#L1-L1" target="_blank" rel="noopener noreferrer">`Stock` (1:1)</a>
+
+
+
+
+
+### Retrosynthesis Search Algorithms
+
+This component encapsulates the various search algorithms used to explore the retrosynthetic reaction network. It includes implementations of algorithms like Breadth-First Search, DFPn (Depth-First Proof Number search), MCTS (Monte Carlo Tree Search), and Retro* search, which are the core engines for finding synthetic routes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/dfpn/search_tree.py#L1-L1" target="_blank" rel="noopener noreferrer">`SearchTree` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/dfpn/search_tree.py#L1-L1" target="_blank" rel="noopener noreferrer">`SearchTree` (1:1)</a>
+
+- `MctsSearchTree` (1:1)
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/dfpn/search_tree.py#L1-L1" target="_blank" rel="noopener noreferrer">`SearchTree` (1:1)</a>
+
+
+
+
+
+### Route Analysis & Post-processing
+
+This component is dedicated to the analysis and post-processing of the generated retrosynthetic routes. It includes functionalities for collecting, organizing, and analyzing the discovered reaction trees, providing insights into the feasibility and characteristics of the proposed synthetic pathways.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `RouteCollection` (1:1)
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/analysis/tree_analysis.py#L1-L1" target="_blank" rel="noopener noreferrer">`TreeAnalysis` (1:1)</a>
+
+
+
+
+
+### User Interfaces [[Expand]](./User_Interfaces.md)
+
+This component provides the various interfaces through which users can interact with the `aizynthfinder` application. This includes command-line interfaces (CLI) for scripting and batch processing, and graphical user interfaces (GUI) for interactive exploration and visualization of retrosynthesis results.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `AiZynthApp` (1:1)
+
+- `ParetoFrontsGUI` (1:1)
+
+- `ClusteringGUI` (1:1)
+
+
+
+
+
+### Utility Functions & External Models
+
+This component comprises general-purpose utility functions and modules for integrating with external machine learning models. It includes functionalities for handling broken bonds, calculating synthetic complexity scores, and providing interfaces for local or remote (gRPC/REST) AI models used in policy expansion or filtering.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `BrokenBonds` (1:1)
+
+- `SCScore` (1:1)
+
+- `LocalOnnxModel` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Chemical_Domain_Model.md
+++ b/.codeboarding/Chemical_Domain_Model.md
@@ -1,0 +1,299 @@
+```mermaid
+
+graph LR
+
+    Chemical_Domain_Model["Chemical Domain Model"]
+
+    Search_Algorithms["Search Algorithms"]
+
+    Context_Configuration["Context & Configuration"]
+
+    Analysis_Reporting["Analysis & Reporting"]
+
+    Reaction_Tree_Representation["Reaction Tree Representation"]
+
+    Application_Orchestrator["Application Orchestrator"]
+
+    User_Interfaces["User Interfaces"]
+
+    Utility_Helper_Functions["Utility & Helper Functions"]
+
+    Search_Algorithms -- "uses" --> Chemical_Domain_Model
+
+    Context_Configuration -- "uses" --> Chemical_Domain_Model
+
+    Search_Algorithms -- "uses" --> Context_Configuration
+
+    Application_Orchestrator -- "uses" --> Search_Algorithms
+
+    Context_Configuration -- "uses" --> Chemical_Domain_Model
+
+    Context_Configuration -- "uses" --> Utility_Helper_Functions
+
+    Application_Orchestrator -- "uses" --> Context_Configuration
+
+    Analysis_Reporting -- "uses" --> Chemical_Domain_Model
+
+    Analysis_Reporting -- "uses" --> Reaction_Tree_Representation
+
+    Application_Orchestrator -- "uses" --> Analysis_Reporting
+
+    User_Interfaces -- "uses" --> Analysis_Reporting
+
+    Reaction_Tree_Representation -- "uses" --> Chemical_Domain_Model
+
+    Search_Algorithms -- "uses" --> Reaction_Tree_Representation
+
+    Application_Orchestrator -- "uses" --> Search_Algorithms
+
+    Application_Orchestrator -- "uses" --> Context_Configuration
+
+    Application_Orchestrator -- "uses" --> Analysis_Reporting
+
+    Application_Orchestrator -- "uses" --> Chemical_Domain_Model
+
+    User_Interfaces -- "uses" --> Application_Orchestrator
+
+    User_Interfaces -- "uses" --> Chemical_Domain_Model
+
+    Chemical_Domain_Model -- "uses" --> Utility_Helper_Functions
+
+    Analysis_Reporting -- "uses" --> Utility_Helper_Functions
+
+    click Chemical_Domain_Model href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Chemical_Domain_Model.md" "Details"
+
+    click Application_Orchestrator href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Application_Orchestrator.md" "Details"
+
+    click User_Interfaces href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//User_Interfaces.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The Chemical Domain Model is a foundational component within aizynthfinder, serving as the common language and data representation for all cheminformatics-related operations. It defines the core data structures for chemical molecules and retro-reactions, along with essential chemical operations and serialization/deserialization capabilities. Its centrality is evident as almost all other major components directly interact with or depend on its defined objects.
+
+
+
+### Chemical Domain Model [[Expand]](./Chemical_Domain_Model.md)
+
+Defines the fundamental data structures for representing chemical molecules (Molecule, TreeMolecule, UniqueMolecule) and retro-reactions (RetroReaction, FixedRetroReaction, SmilesBasedRetroReaction, TemplatedRetroReaction), along with core chemical operations and serialization/deserialization. It provides the common language and data representation for all cheminformatics-related components, ensuring consistent handling of chemical data throughout the application.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/mol.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.mol`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/mol.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.mol.Molecule`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/mol.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.mol.TreeMolecule`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/mol.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.mol.UniqueMolecule`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/reaction.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.reaction`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/reaction.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.reaction.RetroReaction`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/reaction.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.reaction.FixedRetroReaction`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/reaction.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.reaction.SmilesBasedRetroReaction`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/reaction.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.reaction.TemplatedRetroReaction`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/serialization.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.serialization`</a>
+
+
+
+
+
+### Search Algorithms
+
+Implements retrosynthetic search algorithms (e.g., MCTS, DFPN, Retro*Star, Breadth-First search) to explore chemical reaction pathways. It relies heavily on the Chemical Domain Model to build and traverse search trees.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.mcts`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.dfpn`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.breadth_first`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.retrostar`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.nodes`</a>
+
+- `aizynthfinder.search.nodes.MoleculeNode`
+
+- `aizynthfinder.search.nodes.ReactionNode`
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.search_tree`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/andor_trees.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.andor_trees`</a>
+
+
+
+
+
+### Context & Configuration
+
+Manages the application's configuration, policy expansion strategies, filter strategies, scoring functions, and stock management. It provides the contextual information and pluggable components that guide the search process, operating on or producing Chemical Domain Model objects.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.policy`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.scoring`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.stock`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/config.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.config`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/collection.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.collection`</a>
+
+
+
+
+
+### Analysis & Reporting
+
+Provides modules for post-processing and analyzing search results, generating synthetic routes, and visualizing reaction trees. It interprets and presents data using Chemical Domain Model objects and Reaction Tree Representation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/analysis/tree_analysis.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.analysis.tree_analysis`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/analysis/routes.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.analysis.routes`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/analysis/utils.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.analysis.utils`</a>
+
+
+
+
+
+### Reaction Tree Representation
+
+Responsible for constructing, loading, and manipulating reaction trees, which are fundamental data structures representing the discovered synthetic pathways. It relies on Molecule and RetroReaction objects from the Chemical Domain Model.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/reactiontree.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.reactiontree.reactiontree`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/reactiontree.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.reactiontree.reactiontree_loader`</a>
+
+
+
+
+
+### Application Orchestrator [[Expand]](./Application_Orchestrator.md)
+
+Contains the main application logic and entry points, orchestrating the interactions between the Search Algorithms, Context & Configuration, and Analysis & Reporting components to perform retrosynthetic planning.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.aizynthfinder`</a>
+
+
+
+
+
+### User Interfaces [[Expand]](./User_Interfaces.md)
+
+Provides the presentation layer for user interaction, including command-line tools and a graphical user interface. It interacts with the Application Orchestrator and directly with the Chemical Domain Model for input and output of chemical structures.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/interfaces/aizynthcli.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.interfaces.aizynthcli`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/interfaces/aizynthapp.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.interfaces.aizynthapp`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.interfaces.gui`</a>
+
+
+
+
+
+### Utility & Helper Functions
+
+Offers a collection of general-purpose utility functions and helper classes for various operations across the application, including chemical bond manipulation, exception handling, logging, data loading, type validation, image rendering, and integration with external machine learning models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/bonds.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.bonds`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/exceptions.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.exceptions`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/logging.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.logging`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/loading.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.loading`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/type_utils.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.type_utils`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/image.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.image`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/models.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.models`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/sc_score.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.sc_score`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Configuration_Context_Management.md
+++ b/.codeboarding/Configuration_Context_Management.md
@@ -1,0 +1,251 @@
+```mermaid
+
+graph LR
+
+    Configuration["Configuration"]
+
+    ContextCollection["ContextCollection"]
+
+    ExpansionPolicy["ExpansionPolicy"]
+
+    ExpansionStrategy["ExpansionStrategy"]
+
+    FilterPolicy["FilterPolicy"]
+
+    FilterStrategy["FilterStrategy"]
+
+    ScorerCollection["ScorerCollection"]
+
+    Scorer["Scorer"]
+
+    Stock["Stock"]
+
+    StockQueryMixin["StockQueryMixin"]
+
+    Configuration -- "initializes" --> ExpansionPolicy
+
+    Configuration -- "initializes" --> FilterPolicy
+
+    Configuration -- "initializes" --> ScorerCollection
+
+    Configuration -- "initializes" --> Stock
+
+    ExpansionPolicy -- "inherits from" --> ContextCollection
+
+    FilterPolicy -- "inherits from" --> ContextCollection
+
+    ScorerCollection -- "inherits from" --> ContextCollection
+
+    Stock -- "inherits from" --> ContextCollection
+
+    Configuration -- "configures" --> ContextCollection
+
+    ExpansionPolicy -- "manages" --> ExpansionStrategy
+
+    FilterPolicy -- "manages" --> FilterStrategy
+
+    ScorerCollection -- "manages" --> Scorer
+
+    Stock -- "manages" --> StockQueryMixin
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Configuration & Context Management` subsystem is the backbone for managing application settings and dynamically injecting various strategies (policies, scorers, stock sources) into the `aizynthfinder` application. It adheres strongly to the Strategy Pattern and Dependency Injection principles, making the system highly modular, extensible, and configurable.
+
+
+
+### Configuration
+
+This is the central configuration manager. It is responsible for loading application settings from various sources (e.g., YAML files), parsing them, and then using these settings to initialize and provide instances of other core components like `ExpansionPolicy`, `FilterPolicy`, `ScorerCollection`, and `Stock`. It acts as a primary dependency injector, ensuring that other parts of the application receive pre-configured strategy instances.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/config.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.config.Configuration`</a>
+
+
+
+
+
+### ContextCollection
+
+This is an abstract base class that provides a generic mechanism for managing collections of pluggable strategies. It defines the interface for adding, retrieving, and iterating over different implementations of a specific type of strategy. `ExpansionPolicy`, `FilterPolicy`, `ScorerCollection`, and `Stock` all inherit from this class, leveraging its capabilities for dynamic strategy management.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/collection.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.collection.ContextCollection`</a>
+
+
+
+
+
+### ExpansionPolicy
+
+Manages and provides access to various "expansion strategies." These strategies define how a target molecule can be retro-synthetically expanded into possible precursor molecules, often using reaction templates or machine learning models. It selects and applies the appropriate `ExpansionStrategy` based on the current configuration.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/policies.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.policy.policies.ExpansionPolicy`</a>
+
+
+
+
+
+### ExpansionStrategy
+
+An abstract base class defining the interface for concrete expansion algorithms. Implementations of this class (e.g., `TemplateBasedExpansionStrategy`, `MultiExpansionStrategy`) perform the actual chemical transformations to suggest precursors.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/expansion_strategies.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.policy.expansion_strategies.ExpansionStrategy`</a>
+
+
+
+
+
+### FilterPolicy
+
+Manages and provides access to "filter strategies." These strategies are used to prune or filter out undesirable reactions or molecules during the retrosynthetic search, based on criteria like chemical properties, reaction feasibility, or other constraints.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/policies.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.policy.policies.FilterPolicy`</a>
+
+
+
+
+
+### FilterStrategy
+
+An abstract base class defining the interface for concrete filtering algorithms. Implementations (e.g., `BondFilter`, `ReactantsCountFilter`) apply specific rules to accept or reject molecules or reactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/filter_strategies.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.policy.filter_strategies.FilterStrategy`</a>
+
+
+
+
+
+### ScorerCollection
+
+Manages and provides access to various "scoring functions." These functions evaluate the quality or desirability of molecules, reactions, or entire synthetic routes, enabling multi-objective optimization of synthetic plans.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/scoring/collection.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.scoring.collection.ScorerCollection`</a>
+
+
+
+
+
+### Scorer
+
+An abstract base class defining the interface for concrete scoring functions. Implementations (e.g., `FractionInStockScorer`, `RouteCostScorer`) calculate a numerical score based on specific criteria.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/scoring/scorers.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.scoring.scorers.Scorer`</a>
+
+
+
+
+
+### Stock
+
+Manages and provides access to chemical stock information. It allows the application to determine if a molecule is readily available as a starting material, integrating with various stock databases or in-memory collections via `StockQueryMixin` implementations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/stock.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.stock.stock.Stock`</a>
+
+
+
+
+
+### StockQueryMixin
+
+An abstract base class defining the interface for querying stock availability. Implementations (e.g., `InMemoryInchiKeyQuery`, `MolbloomFilterQuery`) provide specific methods for checking if a molecule is in stock.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/queries.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.stock.queries.StockQueryMixin`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Retrosynthetic_Search_Engines.md
+++ b/.codeboarding/Retrosynthetic_Search_Engines.md
@@ -1,0 +1,245 @@
+```mermaid
+
+graph LR
+
+    Retrosynthetic_Search_Engines["Retrosynthetic Search Engines"]
+
+    AndOrTreeBase["AndOrTreeBase"]
+
+    MctsSearchTree["MctsSearchTree"]
+
+    DfpnSearchTree["DfpnSearchTree"]
+
+    BreadthFirstSearchTree["BreadthFirstSearchTree"]
+
+    RetrostarSearchTree["RetrostarSearchTree"]
+
+    MoleculeCost["MoleculeCost"]
+
+    Molecule["Molecule"]
+
+    Configuration["Configuration"]
+
+    DfpnSearchTree -- "inherits from" --> AndOrTreeBase
+
+    BreadthFirstSearchTree -- "inherits from" --> AndOrTreeBase
+
+    RetrostarSearchTree -- "inherits from" --> AndOrTreeBase
+
+    MctsSearchTree -- "uses" --> Configuration
+
+    MctsSearchTree -- "uses" --> Molecule
+
+    DfpnSearchTree -- "uses" --> Configuration
+
+    BreadthFirstSearchTree -- "uses" --> Configuration
+
+    RetrostarSearchTree -- "uses" --> MoleculeCost
+
+    RetrostarSearchTree -- "uses" --> Configuration
+
+    MoleculeCost -- "uses" --> Configuration
+
+    AndOrTreeBase -- "uses" --> Molecule
+
+    Retrosynthetic_Search_Engines -- "orchestrates" --> MctsSearchTree
+
+    Retrosynthetic_Search_Engines -- "orchestrates" --> DfpnSearchTree
+
+    Retrosynthetic_Search_Engines -- "orchestrates" --> BreadthFirstSearchTree
+
+    Retrosynthetic_Search_Engines -- "orchestrates" --> RetrostarSearchTree
+
+    click Retrosynthetic_Search_Engines href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Retrosynthetic_Search_Engines.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Analysis of the 'Retrosynthetic Search Engines' component and its related components within the 'aizynthfinder' project, detailing their structure, flow, and purpose.
+
+
+
+### Retrosynthetic Search Engines [[Expand]](./Retrosynthetic_Search_Engines.md)
+
+This is the overarching component that orchestrates various search algorithms to explore the chemical reaction space and discover synthetic pathways. It acts as the control center, initiating and managing the search process using different strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/mcts/search.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.mcts.search`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/dfpn/search_tree.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.dfpn.search_tree`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/breadth_first/search_tree.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.breadth_first.search_tree`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/retrostar/search_tree.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.retrostar.search_tree`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/andor_trees.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.andor_trees`</a>
+
+
+
+
+
+### AndOrTreeBase
+
+This component provides the foundational abstract classes and mixins for representing the retrosynthetic search space as an AND/OR tree. It defines the common structure for nodes (e.g., `MoleculeNode`, `ReactionNode`) and basic operations that specific search algorithms like DFPN, Breadth-First, and Retro* can build upon.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/andor_trees.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.andor_trees`</a>
+
+
+
+
+
+### MctsSearchTree
+
+Implements the Monte Carlo Tree Search (MCTS) algorithm. It manages its specific tree structure and search process, which involves iterative steps of selection, expansion, simulation (rollout), and backpropagation to efficiently explore the search space, particularly useful for large and complex reaction networks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/mcts/search.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.mcts.search`</a>
+
+
+
+
+
+### DfpnSearchTree
+
+Implements the Depth-First Proof-Number Search (DFPN) algorithm. It leverages the `AndOrTreeBase` to perform a depth-first search, maintaining proof and disproof numbers to efficiently find provable or disprovable synthetic routes, guaranteeing optimality under certain conditions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/dfpn/search_tree.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.dfpn.search_tree`</a>
+
+
+
+
+
+### BreadthFirstSearchTree
+
+Implements the Breadth-First Search (BFS) algorithm, exploring the reaction tree level by level. It also builds upon the `AndOrTreeBase` framework, ensuring that the shortest path (in terms of number of reaction steps) is found first.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/breadth_first/search_tree.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.breadth_first.search_tree`</a>
+
+
+
+
+
+### RetrostarSearchTree
+
+Implements the Retro* search algorithm, a cost-based search that prioritizes pathways with lower overall costs. It integrates with the `AndOrTreeBase` structure and its own `MoleculeCost` component to guide the search based on economic or synthetic feasibility.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/retrostar/search_tree.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.retrostar.search_tree`</a>
+
+
+
+
+
+### MoleculeCost
+
+This component is specific to the Retro* algorithm and is responsible for calculating and managing the costs associated with molecules and reactions within the search tree. These costs directly influence the Retro* algorithm's decision-making, guiding it towards more favorable pathways.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/retrostar/cost.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.retrostar.cost`</a>
+
+
+
+
+
+### Molecule
+
+Represents chemical molecules, serving as the fundamental data unit within all search trees. Nodes in the search tree (e.g., `MoleculeNode`, `ReactionNode`) encapsulate or refer to instances of `Molecule`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/mol.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.chem.mol`</a>
+
+
+
+
+
+### Configuration
+
+A central component that provides all necessary parameters, policies (expansion, filter), and scorers to the search algorithms, enabling flexible and configurable search behavior. It acts as a dependency injection mechanism for various strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/config.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.config`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Retrosynthetic_Strategy_Framework.md
+++ b/.codeboarding/Retrosynthetic_Strategy_Framework.md
@@ -1,0 +1,207 @@
+```mermaid
+
+graph LR
+
+    Policy_Management["Policy Management"]
+
+    Expansion_Strategies["Expansion Strategies"]
+
+    Filter_Strategies["Filter Strategies"]
+
+    Scoring_Strategies["Scoring Strategies"]
+
+    Machine_Learning_Model_Integration["Machine Learning Model Integration"]
+
+    Synthetic_Accessibility_Scoring["Synthetic Accessibility Scoring"]
+
+    Configuration_Management["Configuration Management"]
+
+    Core_Retrosynthesis_Engine["Core Retrosynthesis Engine"]
+
+    Core_Retrosynthesis_Engine -- "uses" --> Policy_Management
+
+    Core_Retrosynthesis_Engine -- "uses" --> Scoring_Strategies
+
+    Policy_Management -- "manages" --> Expansion_Strategies
+
+    Policy_Management -- "manages" --> Filter_Strategies
+
+    Expansion_Strategies -- "uses" --> Machine_Learning_Model_Integration
+
+    Filter_Strategies -- "uses" --> Machine_Learning_Model_Integration
+
+    Scoring_Strategies -- "uses" --> Synthetic_Accessibility_Scoring
+
+    Configuration_Management -- "configures" --> Policy_Management
+
+    Configuration_Management -- "configures" --> Scoring_Strategies
+
+    Configuration_Management -- "configures" --> Machine_Learning_Model_Integration
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Analysis of the Retrosynthetic Strategy Framework in aizynthfinder project.
+
+
+
+### Policy Management
+
+This component is responsible for orchestrating and applying the various expansion and filter strategies during the retrosynthesis search. It acts as a central registry for these policies, allowing the system to dynamically select and execute the appropriate strategy.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/policies.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.policy.policies` (1:100)</a>
+
+
+
+
+
+### Expansion Strategies
+
+This component defines and implements the logic for generating possible retro-reactions from a given molecule. These strategies often leverage machine learning models to predict suitable reaction templates or outcomes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/expansion_strategies.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.policy.expansion_strategies` (1:100)</a>
+
+
+
+
+
+### Filter Strategies
+
+This component defines and implements methods for pruning undesirable or invalid reactions and molecules generated during the retrosynthesis process. This helps in reducing the search space and focusing on chemically sound pathways.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/filter_strategies.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.policy.filter_strategies` (1:100)</a>
+
+
+
+
+
+### Scoring Strategies
+
+This component provides a collection of algorithms and methods for evaluating the quality, feasibility, and desirability of molecules and complete reaction routes. It aggregates various scoring functions to provide a comprehensive assessment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/scoring/collection.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.scoring.collection` (1:100)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/scoring/scorers.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.scoring.scorers` (1:100)</a>
+
+
+
+
+
+### Machine Learning Model Integration
+
+This component offers a standardized interface for loading and interacting with diverse machine learning models, including local Keras/ONNX models and external models accessed via gRPC or REST APIs. It abstracts the underlying ML framework details.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/models.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.models` (1:100)</a>
+
+
+
+
+
+### Synthetic Accessibility Scoring
+
+This specialized component implements the SCScore algorithm, a widely used metric for estimating the synthetic accessibility of a molecule. It's a specific type of scoring function used within the broader `Scoring Strategies`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/sc_score.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils.sc_score` (1:100)</a>
+
+
+
+
+
+### Configuration Management
+
+This component is responsible for loading, parsing, and providing access to the application's configuration settings. It dictates which specific strategies, models, and parameters are used throughout the retrosynthesis process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/config.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.config` (1:100)</a>
+
+
+
+
+
+### Core Retrosynthesis Engine
+
+This is the main orchestrator of the retrosynthesis process, responsible for initiating and managing the search for synthetic routes. It integrates and utilizes the various strategy components to perform the overall retrosynthetic planning.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py#L1-L100" target="_blank" rel="noopener noreferrer">`aizynthfinder.aizynthfinder` (1:100)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Stock_Management.md
+++ b/.codeboarding/Stock_Management.md
@@ -1,0 +1,223 @@
+```mermaid
+
+graph LR
+
+    Stock_Management_Core_Stock_["Stock Management Core (Stock)"]
+
+    Stock_Query_Interface_StockQueryMixin_["Stock Query Interface (StockQueryMixin)"]
+
+    In_Memory_Stock_Query_InMemoryInchiKeyQuery_["In-Memory Stock Query (InMemoryInchiKeyQuery)"]
+
+    Molbloom_Filter_Stock_Query_MolbloomFilterQuery_["Molbloom Filter Stock Query (MolbloomFilterQuery)"]
+
+    MongoDB_Stock_Query_MongoDbInchiKeyQuery_["MongoDB Stock Query (MongoDbInchiKeyQuery)"]
+
+    Configuration_Configuration_["Configuration (Configuration)"]
+
+    Main_Application_Orchestrator_AiZynthFinder_["Main Application Orchestrator (AiZynthFinder)"]
+
+    Scoring_Components["Scoring Components"]
+
+    Search_Algorithms["Search Algorithms"]
+
+    Stock_Management_Core_Stock_ -- "uses" --> Stock_Query_Interface_StockQueryMixin_
+
+    In_Memory_Stock_Query_InMemoryInchiKeyQuery_ -- "implements" --> Stock_Query_Interface_StockQueryMixin_
+
+    Molbloom_Filter_Stock_Query_MolbloomFilterQuery_ -- "implements" --> Stock_Query_Interface_StockQueryMixin_
+
+    MongoDB_Stock_Query_MongoDbInchiKeyQuery_ -- "implements" --> Stock_Query_Interface_StockQueryMixin_
+
+    Configuration_Configuration_ -- "uses" --> Stock_Management_Core_Stock_
+
+    Main_Application_Orchestrator_AiZynthFinder_ -- "uses" --> Stock_Management_Core_Stock_
+
+    Scoring_Components -- "uses" --> Stock_Management_Core_Stock_
+
+    Search_Algorithms -- "uses" --> Stock_Management_Core_Stock_
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Stock Management` component in `aizynthfinder` is crucial for determining the availability of starting materials, which directly impacts the feasibility and scoring of retrosynthetic pathways. It embodies a **Strategy Pattern**, allowing for flexible integration of various stock sources.
+
+
+
+### Stock Management Core (Stock)
+
+This is the central facade for the Stock Management subsystem. It provides a unified interface for checking if a molecule is "in stock" by delegating the actual query to a configured stock query strategy. It acts as the primary entry point for other parts of the application needing stock information.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/stock.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.stock.stock.Stock`</a>
+
+
+
+
+
+### Stock Query Interface (StockQueryMixin)
+
+This abstract base class (mixin) defines the contract for all concrete stock query implementations. It specifies the methods that any stock source must implement to be compatible with the `Stock` component, enforcing the Strategy Pattern.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/queries.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.stock.queries.StockQueryMixin`</a>
+
+
+
+
+
+### In-Memory Stock Query (InMemoryInchiKeyQuery)
+
+A concrete implementation of `StockQueryMixin` that performs stock checks against a collection of InChIKeys loaded directly into memory. This is suitable for smaller, static datasets or testing environments.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/queries.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.stock.queries.InMemoryInchiKeyQuery`</a>
+
+
+
+
+
+### Molbloom Filter Stock Query (MolbloomFilterQuery)
+
+A concrete implementation of `StockQueryMixin` that leverages a `molbloom` filter (a specialized Bloom filter for molecules) for highly efficient, probabilistic stock availability checks. It's optimized for very large datasets where memory footprint and query speed are critical.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/queries.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.stock.queries.MolbloomFilterQuery`</a>
+
+
+
+
+
+### MongoDB Stock Query (MongoDbInchiKeyQuery)
+
+A concrete implementation of `StockQueryMixin` that connects to and queries a MongoDB database for stock availability. This enables persistent, dynamic, and potentially distributed stock management.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/queries.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.stock.queries.MongoDbInchiKeyQuery`</a>
+
+
+
+
+
+### Configuration (Configuration)
+
+This component is responsible for loading and managing the application's settings, including which specific `StockQueryMixin` implementation (e.g., In-Memory, Molbloom, MongoDB) should be instantiated and used by the `Stock` component.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/config.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.config.Configuration`</a>
+
+
+
+
+
+### Main Application Orchestrator (AiZynthFinder)
+
+The top-level class that orchestrates the entire retrosynthetic planning process. It utilizes the `Stock` component to determine the availability of starting materials, which is a critical factor in guiding search algorithms and evaluating the practicality of proposed routes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.aizynthfinder.AiZynthFinder`</a>
+
+
+
+
+
+### Scoring Components
+
+These are specific scoring strategies within the broader Scoring component. They evaluate the "goodness" of a synthetic route or intermediate based on the availability of its precursors in stock, directly querying the `Stock` component.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/scoring/scorers.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.scoring.scorers.FractionInStockScorer`</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/scoring/scorers.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context.scoring.scorers.StockAvailabilityScorer`</a>
+
+
+
+
+
+### Search Algorithms
+
+Various search algorithms (e.g., Breadth-First, DFPn, Retro*) interact with the Stock Management component. They might query stock availability during the search process to prune unfeasible branches, prioritize paths leading to available precursors, or construct reaction trees based on stock status.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/andor_trees.py#L178-L236" target="_blank" rel="noopener noreferrer">`aizynthfinder.search.andor_trees.ReactionTreeFromAndOrTrace` (178:236)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/User_Interfaces.md
+++ b/.codeboarding/User_Interfaces.md
@@ -1,0 +1,219 @@
+```mermaid
+
+graph LR
+
+    User_Interfaces["User Interfaces"]
+
+    CLI_Interface["CLI Interface"]
+
+    Web_GUI_Application["Web GUI Application"]
+
+    GUI_Visualization_Modules["GUI Visualization Modules"]
+
+    Core_AiZynthFinder["Core AiZynthFinder"]
+
+    Analysis_Module["Analysis Module"]
+
+    Context_Management["Context Management"]
+
+    Utility_Module["Utility Module"]
+
+    User_Interfaces -- "specializes" --> CLI_Interface
+
+    User_Interfaces -- "specializes" --> Web_GUI_Application
+
+    CLI_Interface -- "uses" --> Core_AiZynthFinder
+
+    CLI_Interface -- "uses" --> Utility_Module
+
+    Web_GUI_Application -- "uses" --> Core_AiZynthFinder
+
+    Web_GUI_Application -- "orchestrates display of" --> GUI_Visualization_Modules
+
+    Web_GUI_Application -- "retrieves results from" --> Analysis_Module
+
+    Web_GUI_Application -- "uses" --> Utility_Module
+
+    GUI_Visualization_Modules -- "visualizes data from" --> Analysis_Module
+
+    GUI_Visualization_Modules -- "uses" --> Utility_Module
+
+    Core_AiZynthFinder -- "depends on" --> Context_Management
+
+    Core_AiZynthFinder -- "generates results for" --> Analysis_Module
+
+    Core_AiZynthFinder -- "uses" --> Utility_Module
+
+    Analysis_Module -- "uses" --> Utility_Module
+
+    Context_Management -- "uses" --> Utility_Module
+
+    click User_Interfaces href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//User_Interfaces.md" "Details"
+
+    click Context_Management href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Context_Management.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The User Interfaces component in AiZynthFinder serves as the primary interaction layer, offering both a command-line interface (CLI) for scripting and a web-based graphical user interface (GUI) for interactive exploration. This design aligns with the Command Query Responsibility Segregation (CQRS) pattern, where the CLI handles "commands" (initiating searches) and the GUI focuses on "queries" (displaying and analyzing results).
+
+
+
+### User Interfaces [[Expand]](./User_Interfaces.md)
+
+The overarching component providing various means for users to interact with the AiZynthFinder application. It abstracts the different interaction modes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.interfaces`</a>
+
+
+
+
+
+### CLI Interface
+
+Provides a command-line interface for batch processing, scripting, and direct execution of retrosynthetic searches. It parses arguments and orchestrates the core application logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/interfaces/aizynthcli.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.interfaces.aizynthcli`</a>
+
+
+
+
+
+### Web GUI Application
+
+Implements the web-based graphical user interface, managing user sessions, interactive search execution, and data presentation. It acts as the backend for the interactive user experience.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/interfaces/aizynthapp.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.interfaces.aizynthapp.AiZynthApp`</a>
+
+
+
+
+
+### GUI Visualization Modules
+
+Contains specific modules and utilities for rendering interactive visualizations within the web GUI, such as Pareto fronts, clustered results, and search tree displays.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.interfaces.gui`</a>
+
+
+
+
+
+### Core AiZynthFinder
+
+Encapsulates the primary retrosynthetic planning logic, coordinating search algorithms, policy application, and result generation. It's the central engine that both CLI and GUI interact with.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.aizynthfinder.AiZynthFinder`</a>
+
+
+
+
+
+### Analysis Module
+
+Responsible for post-processing and structuring the raw results from the search algorithms into meaningful data representations, such as route collections and tree analyses, suitable for display or further computation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.analysis`</a>
+
+
+
+
+
+### Context Management [[Expand]](./Context_Management.md)
+
+Provides a centralized mechanism for managing application configuration, expansion policies, filter policies, scoring functions, and stock information. It acts as a dependency injection container for various strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.context`</a>
+
+
+
+
+
+### Utility Module
+
+A collection of general-purpose helper functions and common utilities used across different parts of the application, including file handling, logging, and data manipulation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py" target="_blank" rel="noopener noreferrer">`aizynthfinder.utils`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,271 @@
+```mermaid
+
+graph LR
+
+    Application_Orchestrator["Application Orchestrator"]
+
+    Configuration_Context_Management["Configuration & Context Management"]
+
+    Chemical_Domain_Model["Chemical Domain Model"]
+
+    Retrosynthetic_Strategy_Framework["Retrosynthetic Strategy Framework"]
+
+    Stock_Management["Stock Management"]
+
+    Retrosynthetic_Search_Engines["Retrosynthetic Search Engines"]
+
+    Reaction_Pathway_Analysis_Management["Reaction Pathway Analysis & Management"]
+
+    User_Interfaces["User Interfaces"]
+
+    Application_Orchestrator -- "Initializes/Uses" --> Configuration_Context_Management
+
+    Application_Orchestrator -- "Orchestrates" --> Retrosynthetic_Search_Engines
+
+    Configuration_Context_Management -- "Configures" --> Retrosynthetic_Strategy_Framework
+
+    Configuration_Context_Management -- "Configures" --> Stock_Management
+
+    Chemical_Domain_Model -- "Provides Data To" --> Retrosynthetic_Strategy_Framework
+
+    Chemical_Domain_Model -- "Provides Data To" --> Retrosynthetic_Search_Engines
+
+    Retrosynthetic_Strategy_Framework -- "Uses" --> Chemical_Domain_Model
+
+    Retrosynthetic_Strategy_Framework -- "Uses" --> Stock_Management
+
+    Stock_Management -- "Uses" --> Chemical_Domain_Model
+
+    Stock_Management -- "Provides Info To" --> Retrosynthetic_Strategy_Framework
+
+    Retrosynthetic_Search_Engines -- "Uses" --> Chemical_Domain_Model
+
+    Retrosynthetic_Search_Engines -- "Applies" --> Retrosynthetic_Strategy_Framework
+
+    Reaction_Pathway_Analysis_Management -- "Processes Output From" --> Retrosynthetic_Search_Engines
+
+    Reaction_Pathway_Analysis_Management -- "Provides Results To" --> Application_Orchestrator
+
+    User_Interfaces -- "Interacts With" --> Application_Orchestrator
+
+    User_Interfaces -- "Visualizes" --> Reaction_Pathway_Analysis_Management
+
+    click Application_Orchestrator href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Application_Orchestrator.md" "Details"
+
+    click Configuration_Context_Management href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Configuration_Context_Management.md" "Details"
+
+    click Chemical_Domain_Model href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Chemical_Domain_Model.md" "Details"
+
+    click Retrosynthetic_Strategy_Framework href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Retrosynthetic_Strategy_Framework.md" "Details"
+
+    click Stock_Management href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Stock_Management.md" "Details"
+
+    click Retrosynthetic_Search_Engines href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//Retrosynthetic_Search_Engines.md" "Details"
+
+    click User_Interfaces href "https://github.com/MolecularAI/aizynthfinder/blob/master/.codeboarding//User_Interfaces.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `aizynthfinder` project exhibits a well-structured, modular architecture typical of a Scientific AI/ML application in Cheminformatics. The core design emphasizes separation of concerns, allowing for flexible integration of various strategies and algorithms. Here's a high-level data flow overview, identifying the central components and their interactions: Final Architecture Components 1. Application Orchestrator Description: The central control unit that initializes the retrosynthesis process, orchestrates the search, and manages the overall workflow from target molecule input to route collection. It acts as the main entry point for executing a retrosynthesis plan. Source Files: `aizynthfinder/aizynthfinder/aizynthfinder.py` 2. Configuration & Context Management Description: Manages application-wide settings, loads configurations from various sources (e.g., YAML files), and provides a centralized context for accessing and injecting different strategies (policies, scorers, stock sources) throughout the application. It ensures that components are initialized with the correct dependencies. Source Files: `aizynthfinder/context/config.py`, `aizynthfinder/context/collection.py` 3. Chemical Domain Model Description: Defines the fundamental data structures for representing chemical molecules and retro-reactions, along with core chemical operations and serialization/deserialization. It provides the common language and data representation for all cheminformatics-related components. Source Files: `aizynthfinder/chem/mol.py`, `aizynthfinder/chem/reaction.py`, `aizynthfinder/chem/serialization.py` 4. Retrosynthetic Strategy Framework Description: Provides a flexible, plugin-based architecture for defining and managing various strategies involved in retrosynthesis. This includes expansion strategies (generating possible retro-reactions, often using ML models), filter strategies (pruning undesirable reactions or molecules), and scoring strategies (evaluating the quality of molecules and reaction routes). It also encapsulates the integration with underlying machine learning models. Source Files: `aizynthfinder/context/policy/policies.py`, `aizynthfinder/context/policy/expansion_strategies.py`, `aizynthfinder/context/policy/filter_strategies.py`, `aizynthfinder/context/scoring/collection.py`, `aizynthfinder/context/scoring/scorers.py`, `aizynthfinder/plugins/expansion_strategies.py`, `aizynthfinder/utils/models.py`, `aizynthfinder/utils/sc_score.py` 5. Stock Management Description: Manages and queries the availability of starting materials from various configured sources (e.g., in-memory databases, external databases like MongoDB, or bloom filters). It determines if a molecule is "in stock" and thus a valid precursor for a synthetic pathway. Source Files: `aizynthfinder/context/stock/stock.py`, `aizynthfinder/context/stock/queries.py` 6. Retrosynthetic Search Engines Description: Implements various search algorithms (e.g., Monte Carlo Tree Search, Depth-First Proof-Number Search, Breadth-First Search, Retro*) to explore the chemical reaction space and discover synthetic pathways from a target molecule to available precursors. It builds and traverses the reaction tree based on the defined strategies. Source Files: `aizynthfinder/search/mcts/search.py`, `aizynthfinder/search/dfpn/search_tree.py`, `aizynthfinder/search/breadth_first/search_tree.py`, `aizynthfinder/search/retrostar/search_tree.py`, `aizynthfinder/search/andor_trees.py` 7. Reaction Pathway Analysis & Management Description: Collects, stores, and provides functionalities for managing, filtering, analyzing, and visualizing discovered retrosynthetic reaction routes and the underlying search trees. It helps in understanding and selecting the best synthetic pathways, often presenting Pareto-optimal solutions. Source Files: `aizynthfinder/reactiontree/reactiontree.py`, `aizynthfinder/analysis/routes.py`, `aizynthfinder/analysis/tree_analysis.py`, `aizynthfinder/analysis/utils.py` 8. User Interfaces Description: Provides various means for users to interact with the AiZynthFinder application. This includes a command-line interface (CLI) for batch processing and scripting, and a web-based graphical user interface (GUI) for interactive exploration of search trees and reaction routes. Source Files: `aizynthfinder/interfaces/aizynthcli.py`, `aizynthfinder/interfaces/aizynthapp.py`, `aizynthfinder/interfaces/gui/` Relationships and Interactions * Application Orchestrator Initializes/Uses → Configuration & Context Management * Application Orchestrator Orchestrates → Retrosynthetic Search Engines * Configuration & Context Management Configures → Retrosynthetic Strategy Framework * Configuration & Context Management Configures → Stock Management * Chemical Domain Model Provides Data To → Retrosynthetic Strategy Framework * Chemical Domain Model Provides Data To → Retrosynthetic Search Engines * Retrosynthetic Strategy Framework Uses → Chemical Domain Model * Retrosynthetic Strategy Framework Uses → Stock Management * Stock Management Uses → Chemical Domain Model * Stock Management Provides Info To → Retrosynthetic Strategy Framework * Retrosynthetic Search Engines Uses → Chemical Domain Model * Retrosynthetic Search Engines Applies → Retrosynthetic Strategy Framework * Reaction Pathway Analysis & Management Processes Output From → Retrosynthetic Search Engines * Reaction Pathway Analysis & Management Provides Results To → Application Orchestrator * User Interfaces Interacts With → Application Orchestrator * User Interfaces Visualizes → Reaction Pathway Analysis & Management
+
+
+
+### Application Orchestrator [[Expand]](./Application_Orchestrator.md)
+
+The central control unit that initializes the retrosynthesis process, orchestrates the search, and manages the overall workflow from target molecule input to route collection. It acts as the main entry point for executing a retrosynthesis plan.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/aizynthfinder.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/aizynthfinder/aizynthfinder.py` (1:1)</a>
+
+
+
+
+
+### Configuration & Context Management [[Expand]](./Configuration_Context_Management.md)
+
+Manages application-wide settings, loads configurations from various sources (e.g., YAML files), and provides a centralized context for accessing and injecting different strategies (policies, scorers, stock sources) throughout the application. It ensures that components are initialized with the correct dependencies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/config.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/config.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/collection.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/collection.py` (1:1)</a>
+
+
+
+
+
+### Chemical Domain Model [[Expand]](./Chemical_Domain_Model.md)
+
+Defines the fundamental data structures for representing chemical molecules and retro-reactions, along with core chemical operations and serialization/deserialization. It provides the common language and data representation for all cheminformatics-related components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/mol.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/chem/mol.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/reaction.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/chem/reaction.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/chem/serialization.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/chem/serialization.py` (1:1)</a>
+
+
+
+
+
+### Retrosynthetic Strategy Framework [[Expand]](./Retrosynthetic_Strategy_Framework.md)
+
+Provides a flexible, plugin-based architecture for defining and managing various strategies involved in retrosynthesis. This includes expansion strategies (generating possible retro-reactions, often using ML models), filter strategies (pruning undesirable reactions or molecules), and scoring strategies (evaluating the quality of molecules and reaction routes). It also encapsulates the integration with underlying machine learning models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/policies.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/policy/policies.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/expansion_strategies.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/policy/expansion_strategies.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/policy/filter_strategies.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/policy/filter_strategies.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/scoring/collection.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/scoring/collection.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/scoring/scorers.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/scoring/scorers.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/plugins/expansion_strategies.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/plugins/expansion_strategies.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/models.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/utils/models.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/utils/sc_score.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/utils/sc_score.py` (1:1)</a>
+
+
+
+
+
+### Stock Management [[Expand]](./Stock_Management.md)
+
+Manages and queries the availability of starting materials from various configured sources (e.g., in-memory databases, external databases like MongoDB, or bloom filters). It determines if a molecule is "in stock" and thus a valid precursor for a synthetic pathway.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/stock.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/stock/stock.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/context/stock/queries.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/context/stock/queries.py` (1:1)</a>
+
+
+
+
+
+### Retrosynthetic Search Engines [[Expand]](./Retrosynthetic_Search_Engines.md)
+
+Implements various search algorithms (e.g., Monte Carlo Tree Search, Depth-First Proof-Number Search, Breadth-First Search, Retro*) to explore the chemical reaction space and discover synthetic pathways from a target molecule to available precursors. It builds and traverses the reaction tree based on the defined strategies.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/mcts/search.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/search/mcts/search.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/dfpn/search_tree.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/search/dfpn/search_tree.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/breadth_first/search_tree.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/search/breadth_first/search_tree.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/retrostar/search_tree.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/search/retrostar/search_tree.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/search/andor_trees.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/search/andor_trees.py` (1:1)</a>
+
+
+
+
+
+### Reaction Pathway Analysis & Management
+
+Collects, stores, and provides functionalities for managing, filtering, analyzing, and visualizing discovered retrosynthetic reaction routes and the underlying search trees. It helps in understanding and selecting the best synthetic pathways, often presenting Pareto-optimal solutions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `aizynthfinder/reactiontree/reactiontree.py` (1:1)
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/analysis/routes.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/analysis/routes.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/analysis/tree_analysis.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/analysis/tree_analysis.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/analysis/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/analysis/utils.py` (1:1)</a>
+
+
+
+
+
+### User Interfaces [[Expand]](./User_Interfaces.md)
+
+Provides various means for users to interact with the AiZynthFinder application. This includes a command-line interface (CLI) for batch processing and scripting, and a web-based graphical user interface (GUI) for interactive exploration of search trees and reaction routes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/interfaces/aizynthcli.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/interfaces/aizynthcli.py` (1:1)</a>
+
+- <a href="https://github.com/MolecularAI/aizynthfinder/blob/master/aizynthfinder/interfaces/aizynthapp.py#L1-L1" target="_blank" rel="noopener noreferrer">`aizynthfinder/interfaces/aizynthapp.py` (1:1)</a>
+
+- `aizynthfinder/interfaces/gui/` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains documents with mermaid diagrams which represent the codebase on a high-level. You can see how they are rendered here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/aizynthfinder/on_boarding.md

The idea of these documents is to help people get up-to-speed with the aizynthfinder codeabse. Me and a friend are working on helping the get-to-know phase for people who interact with code. I am sure that in MolecularAI (AstraZeneca) there are a lot of scientists who use code mainly as a tool and are not SWE, I would love to get to know if such diagrams can be useful for such people. Further what is your current onboarding process, do you think such automated diagram first documents can be part of it?

We are generating these diagrams with the help of Static Analysis and LLMs.

Any feedback is more than welcome! We already have a github action which I can integrate within this repository and it will update the diagram as development happens!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.